### PR TITLE
Avoid double display of icon and title

### DIFF
--- a/classes/class.ilInteractiveVideoReferencePluginGUI.php
+++ b/classes/class.ilInteractiveVideoReferencePluginGUI.php
@@ -288,8 +288,9 @@ class ilInteractiveVideoReferencePluginGUI extends \ilPageComponentPluginGUI
             return $this->getEmptyResponseString();
         }
 
+        /** @var ilInteractiveVideoReferencePlugin $pl */
         $pl  = $this->getPlugin();
-        $tpl = $pl->getTemplate('tpl.content.html');
+        $tpl = $pl->getTemplate('tpl.content.html', true, true);
         $GLOBALS['tpl']->addCss('./Customizing/global/plugins/Services/COPage/PageComponent/InteractiveVideoReference/templates/xvid_ref.css');
 
         /**
@@ -306,7 +307,7 @@ class ilInteractiveVideoReferencePluginGUI extends \ilPageComponentPluginGUI
                     $light_mode = true;
                 }
                 $player = $obj->getContentAsString($light_mode);
-                $tpl->setVariable('TITLE', $xvid->getTitle());
+                $tpl->setVariable('PLAYER_TITLE', $xvid->getTitle());
                 $tpl->setVariable('PLAYER', $player);
                 return $tpl->get();
             }

--- a/templates/tpl.content.html
+++ b/templates/tpl.content.html
@@ -1,9 +1,9 @@
 <!-- BEGIN player -->
 <img style="height: 35px !important;" id="headerimage" class="media-object"
 	 src="./Customizing/global/plugins/Services/Repository/RepositoryObject/InteractiveVideo/templates/images/icon_xvid.svg">
-<h1 class="media-heading ilHeader" class="lft">{TITLE}</h1>
+<h1 class="media-heading ilHeader" class="lft">{PLAYER_TITLE}</h1>
 {PLAYER}
-<!-- BEGIN player -->
+<!-- END player -->
 <!-- BEGIN container -->
 <ul class="iosInteractiveVideoReferenceContainer">
 	<li>


### PR DESCRIPTION
When the video is linked from the content page, then the title and icon was doubled. The pull requests solves it by removing the player block from the processed template if it is not used.