### PR TITLE
Fix issue loading repo picker (tree) on large installations

### DIFF
--- a/classes/form/class.ilInteractiveVideoReferenceSelectionExplorerGUI.php
+++ b/classes/form/class.ilInteractiveVideoReferenceSelectionExplorerGUI.php
@@ -65,6 +65,7 @@ class ilInteractiveVideoReferenceSelectionExplorerGUI extends ilTreeExplorerGUI
             $element_id = 'iv_explorer_selection';
         }
         parent::__construct($element_id, $a_parent_obj, $a_parent_cmd, $DIC->repositoryTree());
+        $this->setAjax(true);
         $this->setTypeWhiteList(array('root', 'cat', 'crs', 'grp', 'fold', 'xvid'));
     }
 


### PR DESCRIPTION
On large installation the create dialog crashes, since the tree takes too long to load. The tree must be loaded in async mode.